### PR TITLE
v2: InMemoryCache: fix data race on Clear() method

### DIFF
--- a/inMemoryCache_go19.go
+++ b/inMemoryCache_go19.go
@@ -10,7 +10,6 @@ import "sync"
 // for the life of an http request) but it not well suited
 // for long lived cached items.
 type InMemoryCache struct {
-	mu    sync.Mutex
 	items *sync.Map
 }
 
@@ -48,7 +47,8 @@ func (c *InMemoryCache) Delete(key string) bool {
 
 // Clear clears the entire cache
 func (c *InMemoryCache) Clear() {
-	c.mu.Lock()
-	c.items = &sync.Map{}
-	c.mu.Unlock()
+	c.items.Range(func(key interface{}, _ interface{}) bool {
+		c.items.Delete(key)
+		return true
+	})
 }


### PR DESCRIPTION
Fixes #51. Reproduce the issue without this fix by running
```
$ go test -count=1000 -race .
```

And verify the fix running the same test command with this commit applied.

Note: #53 should also be merged to resolve all test failures surfaced with that command.