### PR TITLE
v2: Fix non-deterministic LoadMany result order

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -275,14 +275,16 @@ func (l *Loader) LoadMany(originalContext context.Context, keys []string) ThunkM
 	wg := sync.WaitGroup{}
 
 	wg.Add(length)
-	for i := range keys {
-		go func(i int) {
+	for i, key := range keys {
+		// Request the key serially to ensure the result order is maintained in key order.
+		thunk := l.Load(ctx, key)
+
+		go func(i int, thunk Thunk) {
 			defer wg.Done()
-			thunk := l.Load(ctx, keys[i])
 			result, err := thunk()
 			data[i] = result
 			errors[i] = err
-		}(i)
+		}(i, thunk)
 	}
 
 	go func() {


### PR DESCRIPTION
Fixes #49 for v2 of the library.

To reproduce the issue in #49, run the tests many times.
```
$ go test -count=1000 .
```

To verify the fix, apply these changes and re-run the above command.

Note: #54 should be merged as well for tests to pass.