### PR TITLE
Fix install command in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
   - 1.14
 
 install:
-  - go mod install
+  - go mod download
 
 script:
   - go test -v -race -coverprofile=coverage.txt -covermode=atomic


### PR DESCRIPTION
I noticed that my build was failing in #72. I think it's due to the command used in the `install` step.

From the travis logs:
```
$ go mod install
go mod install: unknown command
```

This was probably meant to be `go mod download`. Hopefully this fixes the build! (Edit: Looks like it did!)