### PR TITLE
Rename cache clearing test so that tests have distinct names

### DIFF
--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -329,7 +329,7 @@ func TestLoader(t *testing.T) {
 		}
 	})
 
-	t.Run("allows clearAll values in cache", func(t *testing.T) {
+	t.Run("clears cache on batch with WithClearCacheOnBatch", func(t *testing.T) {
 		t.Parallel()
 		batchOnlyLoader, loadCalls := BatchOnlyLoader(0)
 		ctx := context.Background()


### PR DESCRIPTION
Hi again! I noticed while debugging the intermittently failing test in https://github.com/graph-gophers/dataloader/pull/73#issuecomment-810251430 that there were two tests with that name ("allows clearAll values in cache"). The second test with this name was added in 13ae83d1. Renamed that second test so that all tests have unique names. Since this test seemed to be testing the `WithClearCacheOnBatch` config method more than the `ClearAll` method, I based the name on that. Happy to update if you have any suggestions. Thanks!