### PR TITLE
ci: add Go 1.16, use default install, ensure module mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: go
 
 go:
+  - 1.16
   - 1.15
   - 1.14
 
-install:
-  - go mod install
+env:
+  - GO111MODULE=on
 
 script:
   - go test -v -race -coverprofile=coverage.txt -covermode=atomic


### PR DESCRIPTION
This PR attempts to fix the same issue as https://github.com/graph-gophers/dataloader/pull/73, but instead uses the default install step offered by TravisCI.

```sh
go get ./...
```

<https://docs.travis-ci.com/user/languages/go/#dependency-management>

We also add Go 1.16 to the build matrix and add `GO111MODULE=on` to ensure we always run builds with module-mode enabled.

