### PR TITLE
test: fix flaky WithClearCacheOnBatch test

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -368,7 +368,7 @@ func (l *Loader) reset() {
 	l.curBatcher = nil
 
 	if l.clearCacheOnBatch {
-		l.cache.Clear()
+		l.ClearAll()
 	}
 }
 


### PR DESCRIPTION
This changes the test assertion to avoid test flake. Fixes #76.

I was unable to find any data races using the `-race` flag for testing. The existing test would rarely fail 0.001% of the time locally on my machine. I changed the test so it's not digging into the cache (which relies on locking external to it's implementation--maybe something to follow up on separately).

I haven't been able to reproduce any test flakiness with this new approach.