### PR TITLE
Panic errors from batch function should not be cached

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 )
@@ -219,6 +220,9 @@ func (l *Loader[K, V]) Load(originalContext context.Context, key K) Thunk[V] {
 		}
 		result.mu.RLock()
 		defer result.mu.RUnlock()
+		if result.value.Error != nil && strings.Contains(result.value.Error.Error(), "Panic") {
+			l.Clear(ctx, key)
+		}
 		return result.value.Data, result.value.Error
 	}
 	defer finish(thunk)

--- a/dataloader.go
+++ b/dataloader.go
@@ -4,9 +4,9 @@ package dataloader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
-	"reflect"
 	"runtime"
 	"sync"
 	"time"
@@ -231,7 +231,8 @@ func (l *Loader[K, V]) Load(originalContext context.Context, key K) Thunk[V] {
 		}
 		result.mu.RLock()
 		defer result.mu.RUnlock()
-		if result.value.Error != nil && reflect.TypeOf(result.value.Error) == reflect.TypeOf(&PanicErrorWrapper{}) {
+		var ev *PanicErrorWrapper
+		if result.value.Error != nil && errors.As(result.value.Error, &ev) {
 			l.Clear(ctx, key)
 		}
 		return result.value.Data, result.value.Error

--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -107,7 +107,7 @@ func TestLoader(t *testing.T) {
 		for _, f := range futures {
 			_, err := f()
 			if err != nil {
-				t.Error("Panic error from batch function is cached")
+				t.Error("Panic error from batch function was cached")
 			}
 		}
 	})
@@ -190,7 +190,7 @@ func TestLoader(t *testing.T) {
 		_, errs = future()
 
 		if len(errs) > 0 {
-			t.Error("Panic error from batch function is cached")
+			t.Error("Panic error from batch function was cached")
 		}
 
 	})

--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -73,6 +73,7 @@ func TestLoader(t *testing.T) {
 		nextFuture := errorCacheLoader.Load(ctx, "1")
 		_, err := nextFuture()
 
+		// Normal errors should be cached.
 		if err == nil {
 			t.Error("Error from batch function was not cached")
 		}

--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -578,7 +578,7 @@ func PanicLoader[K comparable](max int) (*Loader[K, K], *[][]K) {
 
 func PanicCacheLoader[K comparable](max int) (*Loader[K, K], *[][]K) {
 	var loadCalls [][]K
-	panicLoader := NewBatchedLoader(func(_ context.Context, keys []K) []*Result[K] {
+	panicCacheLoader := NewBatchedLoader(func(_ context.Context, keys []K) []*Result[K] {
 		if len(keys) > 1 {
 			panic("Programming error")
 		}
@@ -594,12 +594,12 @@ func PanicCacheLoader[K comparable](max int) (*Loader[K, K], *[][]K) {
 		return returnResult
 
 	}, WithBatchCapacity[K, K](max), withSilentLogger[K, K]())
-	return panicLoader, &loadCalls
+	return panicCacheLoader, &loadCalls
 }
 
 func ErrorCacheLoader[K comparable](max int) (*Loader[K, K], *[][]K) {
 	var loadCalls [][]K
-	panicLoader := NewBatchedLoader(func(_ context.Context, keys []K) []*Result[K] {
+	errorCacheLoader := NewBatchedLoader(func(_ context.Context, keys []K) []*Result[K] {
 		if len(keys) > 1 {
 			var results []*Result[K]
 			for _, key := range keys {
@@ -619,7 +619,7 @@ func ErrorCacheLoader[K comparable](max int) (*Loader[K, K], *[][]K) {
 		return returnResult
 
 	}, WithBatchCapacity[K, K](max), withSilentLogger[K, K]())
-	return panicLoader, &loadCalls
+	return errorCacheLoader, &loadCalls
 }
 
 func BadLoader[K comparable](max int) (*Loader[K, K], *[][]K) {

--- a/dataloader_test.go
+++ b/dataloader_test.go
@@ -600,7 +600,6 @@ func ErrorCacheLoader[K comparable](max int) (*Loader[K, K], *[][]K) {
 	var loadCalls [][]K
 	panicLoader := NewBatchedLoader(func(_ context.Context, keys []K) []*Result[K] {
 		if len(keys) > 1 {
-			//panic("Programming error")
 			var results []*Result[K]
 			for _, key := range keys {
 				results = append(results, &Result[K]{key, fmt.Errorf("this is a test error")})


### PR DESCRIPTION
We currently cache panic errors from batch function. This is a problem because subsequent load calls for the same keys will continue returning  panic errors without calling the batch function again. This PR fixes this issue.