### PR TITLE
Update docs for v7

### DIFF
--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -102,3 +102,9 @@ import "github.com/graph-gophers/dataloader/v6"
 
 [Generics](https://go.dev/doc/tutorial/generics) support has been added.
 With this update, you can now write more type-safe code.
+
+Use the major version tag in the import path.
+
+```go
+import "github.com/graph-gophers/dataloader/v7"
+```

--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -97,3 +97,8 @@ The preferred import method includes the major version tag.
 ```go
 import "github.com/graph-gophers/dataloader/v6"
 ```
+
+## Upgrade from v6 to v7
+
+[Generics](https://go.dev/doc/tutorial/generics) support has been added.
+With this update, you can now write more type-safe code.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ This implementation contains a very basic cache that is intended only to be used
 
 ## Examples
 There are a few basic examples in the example folder.
+
+## See also
+- [TRACE](TRACE.md)
+- [MIGRATE](MIGRATE.md)

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 This is an implementation of [Facebook's DataLoader](https://github.com/facebook/dataloader) in Golang.
 
 ## Install
-`go get -u github.com/graph-gophers/dataloader`
+`go get -u github.com/graph-gophers/dataloader/v7`
 
 ## Usage
 ```go
 // setup batch function - the first Context passed to the Loader's Load
 // function will be provided when the batch function is called.
-batchFn := func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
-  var results []*dataloader.Result
+// this function is registered with the Loader, and the key and value are fixed using generics.
+batchFn := func(ctx context.Context, keys []int) []*dataloader.Result[*User] {
+  var results []*dataloader.Result[*User]
   // do some async work to get data for specified keys
   // append to this list resolved values
   return results
@@ -32,7 +33,7 @@ loader := dataloader.NewBatchedLoader(batchFn)
  * The first context passed to Load is the object that will be passed
  * to the batch function.
  */
-thunk := loader.Load(context.TODO(), dataloader.StringKey("key1")) // StringKey is a convenience method that make wraps string to implement `Key` interface
+thunk := loader.Load(context.TODO(), 5)
 result, err := thunk()
 if err != nil {
   // handle data error


### PR DESCRIPTION
The usability of v7 has greatly improved due to its support for generics, but there may be users who don't notice this due to insufficient documentation.
In this change, I update the documentation to match v7.