### PR TITLE
Stop timer when it's no longer needed

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -481,12 +481,14 @@ func (b *batcher[K, V]) batch(originalContext context.Context) {
 
 // wait the appropriate amount of time for the provided batcher
 func (l *Loader[K, V]) sleeper(b *batcher[K, V], close chan bool) {
+	timer := time.NewTimer(l.wait)
 	select {
 	// used by batch to close early. usually triggered by max batch size
 	case <-close:
+		timer.Stop()
 		return
 	// this will move this goroutine to the back of the callstack?
-	case <-time.After(l.wait):
+	case <-timer.C:
 	}
 
 	// reset


### PR DESCRIPTION
When a batch is triggered by hitting the batch capacity, the timer is no longer needed and the resources associated with it can be released.