### PR TITLE
Support cache skipping for `Load()` calls that throw `SkipCacheError`

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -60,6 +60,20 @@ func (p *PanicErrorWrapper) Error() string {
 	return p.panicError.Error()
 }
 
+// SkipCacheError wraps the error interface.
+// The cache should not store SkipCacheErrors.
+type SkipCacheError struct {
+	err error
+}
+
+func (s *SkipCacheError) Error() string {
+	return s.err.Error()
+}
+
+func NewSkipCacheError(err error) *SkipCacheError {
+	return &SkipCacheError{err: err}
+}
+
 // Loader implements the dataloader.Interface.
 type Loader[K comparable, V any] struct {
 	// the batch function to be used by this loader
@@ -232,7 +246,8 @@ func (l *Loader[K, V]) Load(originalContext context.Context, key K) Thunk[V] {
 		result.mu.RLock()
 		defer result.mu.RUnlock()
 		var ev *PanicErrorWrapper
-		if result.value.Error != nil && errors.As(result.value.Error, &ev) {
+		var es *SkipCacheError
+		if result.value.Error != nil && (errors.As(result.value.Error, &ev) || errors.As(result.value.Error, &es)){
 			l.Clear(ctx, key)
 		}
 		return result.value.Data, result.value.Error


### PR DESCRIPTION
Currently, when using a dataloader with a cache, errors returned by the`BatchFunc` are stored in the cache. 
This might not be the desired result, users might want to be able to decide on caching errors or not depending on the error type.
To support this use case, this PR adds a new error type `SkipCacheError` along with the `NewSkipCacheError` constructor function to allow users to wrap errors they don't want to be cached. 