### PR TITLE
Update README to install v7 with go get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is an implementation of [Facebook's DataLoader](https://github.com/facebook/dataloader) in Golang.
 
 ## Install
-`go get -u github.com/graph-gophers/dataloader`
+`go get -u github.com/graph-gophers/dataloader/v7`
 
 ## Usage
 ```go


### PR DESCRIPTION
The README's `go get` command won't install the latest version of the library - for example:

```
>go mod init graph-gophers-test
go: creating new go.mod: module graph-gophers-test
go: to add module requirements and sums:
        go mod tidy

>go get -u github.com/graph-gophers/dataloader
go: downloading github.com/graph-gophers/dataloader v5.0.0+incompatible
go: downloading github.com/opentracing/opentracing-go v1.2.0
go: added github.com/graph-gophers/dataloader v5.0.0+incompatible
go: added github.com/opentracing/opentracing-go v1.2.0
```

Contrast with the command in the README now:

```
>go mod init graph-gophers-test
go: creating new go.mod: module graph-gophers-test
go: to add module requirements and sums:
        go mod tidy

>go get -u github.com/graph-gophers/dataloader/v7
go: downloading github.com/graph-gophers/dataloader/v7 v7.1.0
go: added github.com/graph-gophers/dataloader/v7 v7.1.0
```