### PR TITLE
Allocate batchRequest only on cache miss

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -227,10 +227,6 @@ func NewBatchedLoader[K comparable, V any](batchFn BatchFunc[K, V], opts ...Opti
 // the registered BatchFunc.
 func (l *Loader[K, V]) Load(originalContext context.Context, key K) Thunk[V] {
 	ctx, finish := l.tracer.TraceLoad(originalContext, key)
-	req := &batchRequest[K, V]{
-		key:  key,
-		done: make(chan struct{}),
-	}
 
 	// We need to lock both the batchLock and cacheLock because the batcher can
 	// reset the cache when either the batchCap or the wait time is reached.
@@ -252,6 +248,13 @@ func (l *Loader[K, V]) Load(originalContext context.Context, key K) Thunk[V] {
 		l.batchLock.Unlock()
 		defer finish(v)
 		return v
+	}
+
+	// Only a cache miss needs a batch request: allocating it (and its channel)
+	// before the cache check above wastes an allocation on every cache hit.
+	req := &batchRequest[K, V]{
+		key:  key,
+		done: make(chan struct{}),
 	}
 
 	thunk := func() (V, error) {


### PR DESCRIPTION
## Summary

`Loader.Load` allocated the `batchRequest` and its `done` channel at the top of the function, before the cache lookup. `req` is only used on a cache **miss** (it's sent to the batcher and read by the returned thunk), so on a cache **hit** it was allocated and immediately discarded — every cached load paid for a struct + channel allocation it never used.

This moves the allocation below the cache-hit early-return so cached loads don't pay for it. No behavioural change: nothing between the cache check and the new allocation site references `req`.

Fixes #122.

## Benchmark

`Load` on a primed/cached key (`-benchmem`):

| | allocs/op | B/op | ns/op |
|---|---|---|---|
| before | 3 | 160 | 45.7 |
| after | 1 | 16 | 20.5 |

## Testing

`go test .` passes. (The pre-existing build failures in `example/lru_cache` and `example/ttl_cache` are unrelated to this change — they fail the same way on unmodified `master`.)